### PR TITLE
Añadido banner remarcando que el repositorio se encuentra archivado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+![Estado del proyecto: Archivado](https://img.shields.io/badge/estado-archivado-lightgrey)
+
+> ⚠️ **Este repositorio ha sido archivado.**  
+> El desarrollo se ha dividido en dos repositorios separados:
+> 
+> - 🌐 [Web Service (página web)](https://github.com/aragonopendata/calidad-cobertura-internet-ws)
+> - 📱 [App (móvil)](https://github.com/aragonopendata/calidad-cobertura-internet-app)
+> 
+> Este repositorio ya no se mantiene y los endpoints de las APIs han cambiado, por lo que se recomiénda encarecidamente consultar los enlaces anteriores para el desarrollo activo.
+
 # De Vodafone API a PostgreSQL con mapa y teselas incluidas
 
 ## Intención

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![Estado del proyecto: Archivado](https://img.shields.io/badge/estado-archivado-lightgrey)
 
-> ⚠️ **Este repositorio ha sido archivado.**  
+> ⚠️ **Este repositorio ha sido archivado** ⚠️
 > El desarrollo se ha dividido en dos repositorios separados:
 > 
 > - 🌐 [Web Service (página web)](https://github.com/aragonopendata/calidad-cobertura-internet-ws)
 > - 📱 [App (móvil)](https://github.com/aragonopendata/calidad-cobertura-internet-app)
 > 
-> Este repositorio ya no se mantiene y los endpoints de las APIs han cambiado, por lo que se recomiénda encarecidamente consultar los enlaces anteriores para el desarrollo activo.
+> Este repositorio ya no se mantiene y los endpoints de las APIs han cambiado, por lo que se recomiénda encarecidamente consultar los enlaces anteriores para el desarrollo activo
 
 # De Vodafone API a PostgreSQL con mapa y teselas incluidas
 


### PR DESCRIPTION
Se añade un banner indicando al usuario que el repositorio actual está archivado y dónde puede encontrar la diseminación de éste, cuyo mantenimiento sí se encuentra activo